### PR TITLE
Optimistic lock on projection_versions

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,8 +3,6 @@ use Mix.Config
 # Print only warnings and errors during test
 config :logger, :console, level: :warn, format: "[$level] $message\n"
 
-config :ex_unit, capture_log: true
-
 config :commanded_ecto_projections,
   ecto_repos: [Commanded.Projections.Repo, Commanded.Projections.ConcurrentRepo],
   repo: Commanded.Projections.Repo

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,7 +6,7 @@ config :logger, :console, level: :warn, format: "[$level] $message\n"
 config :ex_unit, capture_log: true
 
 config :commanded_ecto_projections,
-  ecto_repos: [Commanded.Projections.Repo],
+  ecto_repos: [Commanded.Projections.Repo, Commanded.Projections.ConcurrentRepo],
   repo: Commanded.Projections.Repo
 
 config :commanded_ecto_projections, Commanded.Projections.Repo,
@@ -15,3 +15,10 @@ config :commanded_ecto_projections, Commanded.Projections.Repo,
   password: "postgres",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :commanded_ecto_projections, Commanded.Projections.ConcurrentRepo,
+  database: "commanded_ecto_projections_concurrent_test",
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  pool_size: 5

--- a/lib/projections/ecto.ex
+++ b/lib/projections/ecto.ex
@@ -59,10 +59,6 @@ defmodule Commanded.Projections.Ecto do
         projection_name = Map.fetch!(metadata, :handler_name)
         event_number = Map.fetch!(metadata, :event_number)
 
-        changeset =
-          %ProjectionVersion{projection_name: projection_name}
-          |> ProjectionVersion.changeset(%{last_seen_event_number: event_number})
-
         prefix = schema_prefix(event, metadata)
 
         multi =
@@ -71,13 +67,10 @@ defmodule Commanded.Projections.Ecto do
             version =
               case repo.get(ProjectionVersion, projection_name, prefix: prefix) do
                 nil ->
-                  repo.insert!(
-                    %ProjectionVersion{
-                      projection_name: projection_name,
-                      last_seen_event_number: 0
-                    },
-                    prefix: prefix
-                  )
+                  %ProjectionVersion{
+                    projection_name: projection_name,
+                    last_seen_event_number: 0
+                  }
 
                 version ->
                   version
@@ -89,7 +82,15 @@ defmodule Commanded.Projections.Ecto do
               {:error, :already_seen_event}
             end
           end)
-          |> Ecto.Multi.update(:projection_version, changeset, prefix: prefix)
+          |> Ecto.Multi.insert_or_update(
+            :projection_version,
+            fn %{verify_projection_version: %{version: version}} ->
+              version
+              |> Ecto.Changeset.optimistic_lock(:last_seen_event_number, fn _ -> event_number end)
+              |> Ecto.Changeset.change(last_seen_event_number: event_number)
+            end,
+            prefix: prefix
+          )
 
         with %Ecto.Multi{} = multi <- apply(multi_fn, [multi]),
              {:ok, changes} <- transaction(multi) do

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,8 @@ defmodule Commanded.Projections.Ecto.Mixfile do
   defp aliases do
     [
       setup: ["ecto.create", "ecto.migrate"],
-      reset: ["ecto.drop", "setup"]
+      reset: ["ecto.drop", "setup"],
+      test: ["setup", "test"]
     ]
   end
 

--- a/priv/concurrent_repo/migrations/20170609113553_create_projection_versions.exs
+++ b/priv/concurrent_repo/migrations/20170609113553_create_projection_versions.exs
@@ -1,0 +1,12 @@
+defmodule Commanded.Projections.ConcurrentRepo.Migrations.CreateProjectionVersions do
+  use Ecto.Migration
+
+  def change do
+    create table(:projection_versions, primary_key: false) do
+      add(:projection_name, :text, primary_key: true)
+      add(:last_seen_event_number, :bigint)
+
+      timestamps(type: :naive_datetime_usec)
+    end
+  end
+end

--- a/priv/concurrent_repo/migrations/20170929080308_create_projection_version_with_prefix.exs
+++ b/priv/concurrent_repo/migrations/20170929080308_create_projection_version_with_prefix.exs
@@ -1,0 +1,20 @@
+defmodule Commanded.Projections.ConcurrentRepo.Migrations.CreateProjectionVersionWithPrefix do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE SCHEMA test")
+
+    create table(:projection_versions, primary_key: false, prefix: "test") do
+      add(:projection_name, :text, primary_key: true)
+      add(:last_seen_event_number, :bigint)
+
+      timestamps(type: :naive_datetime_usec)
+    end
+  end
+
+  def down do
+    drop(table(:projection_versions, prefix: "test"))
+
+    execute("DROP SCHEMA test CASCADE")
+  end
+end

--- a/test/projections/concurrent_projector_test.exs
+++ b/test/projections/concurrent_projector_test.exs
@@ -1,0 +1,110 @@
+defmodule Commanded.Projections.ConcurrentProjectorTest do
+  use ExUnit.Case
+
+  alias Commanded.Projections.Events.AnEvent
+  alias Commanded.Projections.Projection
+  alias Commanded.Projections.ConcurrentRepo
+
+  defmodule Projector do
+    use Commanded.Projections.Ecto,
+      application: TestApplication,
+      repo: ConcurrentRepo,
+      name: "Projector"
+
+    project %AnEvent{name: name}, _metadata, fn multi ->
+      Process.sleep(500)
+      Ecto.Multi.insert(multi, :my_projection, %Projection{name: name})
+    end
+  end
+
+  setup do
+    reset!()
+    start_supervised!(TestApplication)
+    :ok
+  end
+
+  defp reset! do
+    ConcurrentRepo.delete_all(Projection)
+    ConcurrentRepo.delete_all(Projector.ProjectionVersion)
+    :ok
+  end
+
+  test "one should be failed when trying to create a new projection version" do
+    task1 =
+      Task.async(fn ->
+        try do
+          Projector.handle(%AnEvent{name: "event_1"}, %{
+            handler_name: "Projector",
+            event_number: 1
+          })
+        catch
+          kind, reason -> {:catch, kind, reason}
+        end
+      end)
+
+    task2 =
+      Task.async(fn ->
+        try do
+          Projector.handle(%AnEvent{name: "event_1"}, %{
+            handler_name: "Projector",
+            event_number: 1
+          })
+        catch
+          kind, reason -> {:catch, kind, reason}
+        end
+      end)
+
+    assert {[:ok],
+            [
+              {:catch, :error,
+               %Ecto.ConstraintError{constraint: "projection_versions_pkey", type: :unique}}
+            ]} =
+             Task.await_many([task1, task2])
+             |> Enum.split_with(&(&1 == :ok))
+
+    assert %Projector.ProjectionVersion{last_seen_event_number: 1} =
+             ConcurrentRepo.get(Projector.ProjectionVersion, "Projector")
+
+    assert [%Projection{name: "event_1"}] = ConcurrentRepo.all(Projection)
+  end
+
+  test "one should be failed with stale error when trying to update projection version" do
+    Projector.handle(%AnEvent{name: "event_1"}, %{
+      handler_name: "Projector",
+      event_number: 1
+    })
+
+    task1 =
+      Task.async(fn ->
+        try do
+          Projector.handle(%AnEvent{name: "event_2"}, %{
+            handler_name: "Projector",
+            event_number: 2
+          })
+        catch
+          kind, reason -> {:catch, kind, reason}
+        end
+      end)
+
+    task2 =
+      Task.async(fn ->
+        try do
+          Projector.handle(%AnEvent{name: "event_2"}, %{
+            handler_name: "Projector",
+            event_number: 2
+          })
+        catch
+          kind, reason -> {:catch, kind, reason}
+        end
+      end)
+
+    assert {[:ok], [{:catch, :error, %Ecto.StaleEntryError{}}]} =
+             Task.await_many([task1, task2]) |> Enum.split_with(&(&1 == :ok))
+
+    assert %Projector.ProjectionVersion{last_seen_event_number: 2} =
+             ConcurrentRepo.get(Projector.ProjectionVersion, "Projector")
+
+    assert [%Projection{name: "event_1"}, %Projection{name: "event_2"}] =
+             ConcurrentRepo.all(Projection)
+  end
+end

--- a/test/support/concurrent_repo.ex
+++ b/test/support/concurrent_repo.ex
@@ -1,0 +1,5 @@
+defmodule Commanded.Projections.ConcurrentRepo do
+  use Ecto.Repo,
+    otp_app: :commanded_ecto_projections,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -17,6 +17,9 @@ end
 Ecto.Migrator.up(Repo, 99_999_999_999_999, CreateProjections)
 Ecto.Migrator.up(ConcurrentRepo, 99_999_999_999_999, CreateProjections)
 
-ExUnit.start()
+ExUnit.start(
+  capture_log: true,
+  exclude: [:skip]
+)
 
 Ecto.Adapters.SQL.Sandbox.mode(Repo, :manual)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,8 @@
 alias Commanded.Projections.Repo
+alias Commanded.Projections.ConcurrentRepo
 
 {:ok, _} = Repo.start_link()
+{:ok, _} = ConcurrentRepo.start_link()
 
 defmodule CreateProjections do
   use Ecto.Migration
@@ -12,7 +14,8 @@ defmodule CreateProjections do
   end
 end
 
-Ecto.Migrator.up(Repo, 20_170_609_120_000, CreateProjections)
+Ecto.Migrator.up(Repo, 99_999_999_999_999, CreateProjections)
+Ecto.Migrator.up(ConcurrentRepo, 99_999_999_999_999, CreateProjections)
 
 ExUnit.start()
 


### PR DESCRIPTION
the failed test on the master branch can be viewed at `concurrent-test` branch https://github.com/zipmex/commanded-ecto-projections/tree/concurrent-test
